### PR TITLE
Update PersonFinderStub.java

### DIFF
--- a/BasePatterns/Registry/SingletonRegistry/PersonFinderStub.java
+++ b/BasePatterns/Registry/SingletonRegistry/PersonFinderStub.java
@@ -1,6 +1,6 @@
 package BasePatterns.Registry.SingletonRegistry;
 
-public class PersonFinderStub {
+public class PersonFinderStub extends PersonFinder{
     public Person find(long id) {
         if (id == 1) {
             return new Person("Fowler", "Martin", 10);


### PR DESCRIPTION
in order to set  `personFinder = new PersonFinderStub()` in `RegistryStub` class, `PersonFinderStub` class needs to extends `PersonFinder` class